### PR TITLE
Make payer information optional

### DIFF
--- a/src/Message/RestCreateOrderRequest.php
+++ b/src/Message/RestCreateOrderRequest.php
@@ -57,22 +57,29 @@ class RestCreateOrderRequest extends RestAuthorizeRequest {
             }
         }
 
-        $body['payer']['email_address'] = $this->getEmailAddress();
-        $body['payer']['name'] = [
-            'given_name' => $this->getGivenName(),
-            'surname' => $this->getSurname(),
-        ];
-        $body['payer']['phone'] = [
-            'phone_number' => [
-                'national_number' => $this->getPhoneNumber(),
-            ],
-        ];
-        $body['payer']['address'] = [
-            'address_line_1' => $this->getAddress(),
-            'admin_area_2' => $this->getCity(),
-            'postal_code' => $this->getPostcode(),
-            'country_code' => $this->getCountryCode(),
-        ];
+        if($this->getEmailAddress())
+            $body['payer']['email_address'] = $this->getEmailAddress();
+            
+        if($this->getSurname()&&$this->getGivenName())
+            $body['payer']['name'] = [
+                'given_name' => $this->getGivenName(),
+                'surname' => $this->getSurname(),
+            ];
+        
+        if($this->getPhoneNumber())
+            $body['payer']['phone'] = [
+                'phone_number' => [
+                    'national_number' => $this->getPhoneNumber(),
+                ],
+            ];
+        
+        if($this->getAddress()&&$this->getCity()&&$this->getPostcode()&&$this->getCountryCode())
+            $body['payer']['address'] = [
+                'address_line_1' => $this->getAddress(),
+                'admin_area_2' => $this->getCity(),
+                'postal_code' => $this->getPostcode(),
+                'country_code' => $this->getCountryCode(),
+            ];
 
         return $body;
     }


### PR DESCRIPTION
According to PayPal's documentation, the payer information is an optional information to be passed. The current `RestCreateOrderRequest` class expects instead payer information to be passed which results in a `400 error` malformed request if the payer information cannot be set.

**Solution:** the payer information is only set as long as the payer information can be set.